### PR TITLE
Add SEO and AEO foundation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,4 +84,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.2.22
+   2.6.9

--- a/SEO_AEO_PLAN.md
+++ b/SEO_AEO_PLAN.md
@@ -1,0 +1,112 @@
+# SEO and AEO Plan for 1ma.dev
+
+This plan is for `1ma.dev`, the personal technical blog running on Jekyll.
+
+The goal is not to chase broad keywords like "software" or "programming". That is a bad market for a small personal blog. The practical goal is to win specific long-tail searches from developers and make the best posts easy for answer engines to understand, quote, and cite.
+
+## Strategy 1: Technical Discoverability
+
+Search engines and answer engines need to crawl, index, and understand the site without friction.
+
+### Actions
+
+- Keep `sitemap.xml` and `feed.xml` generated and linked from the HTML head.
+- Add a source `robots.txt` that allows normal search crawlers and answer-engine crawlers.
+- Add `llms.txt` with a concise description of the blog and the most useful public URLs.
+- Replace the old Universal Analytics tag with the GA4 measurement ID for the blog property.
+- Keep `jekyll-seo-tag` enabled and verify generated metadata after every template change.
+- Use Google Search Console for sitemap submission, indexing checks, query data, and coverage issues.
+
+### Success Checks
+
+- `robots.txt`, `llms.txt`, `sitemap.xml`, and `feed.xml` are available in the built site.
+- Production pages include GA4, not the old `UA-*` tag.
+- Search Console shows the sitemap as discovered and no major indexing blockers.
+
+## Strategy 2: Long-Tail Developer Topic Clusters
+
+The blog should target concrete questions developers actually search for. Broad opinion pieces are fine, but they need supporting practical posts and internal links.
+
+### Initial Clusters
+
+1. Ruby and Rails
+   - Ruby object design
+   - Rails defaults
+   - testing practices
+   - avoiding unnecessary abstractions
+
+2. Simple Deployments and Operations
+   - Dokku
+   - Apache Superset
+   - process debugging
+   - small app operations
+
+3. Engineering Judgment
+   - boring technology
+   - side projects
+   - tool selection
+   - small-team software decisions
+
+### Actions
+
+- Create one index page per cluster once there are enough posts to justify it.
+- Add internal links from older posts to newer related posts.
+- Give every new post a clear excerpt that states the problem and result.
+- Prefer titles that match developer intent: "How to...", "Why...", "When to...", "What to choose...".
+
+### Success Checks
+
+- Each new post links to at least one related existing post when relevant.
+- Existing high-fit posts are refreshed with better excerpts and internal links.
+- Search Console starts showing specific long-tail queries, not just branded or homepage traffic.
+
+## Strategy 3: Answer-First Content for AEO
+
+Answer engines prefer pages where the main answer, definitions, and criteria are easy to extract. This does not mean writing bland SEO sludge. It means putting the useful answer where machines and humans can both find it.
+
+### Actions
+
+- Add a short "Quick answer" section near the top of practical and opinion posts.
+- Use question-shaped headings when they match the query.
+- Include concise definitions and criteria lists.
+- Add a short FAQ only when the topic naturally has follow-up questions.
+- Keep author and editor context visible for the Robertito column.
+- Cite or link to related internal posts where it helps establish topical depth.
+
+### Success Checks
+
+- Key posts can be summarized accurately from the first screen of content.
+- Posts contain extractable definitions, criteria, and examples.
+- GA4 referral reports include AI/search referrers over time, such as `chatgpt.com`, `perplexity.ai`, and Google organic search.
+
+## Publishing Checklist
+
+Before publishing a new post:
+
+- The title matches a real query or a clear editorial angle.
+- The excerpt states the useful promise of the post.
+- The first screen contains the answer or thesis.
+- Headings are descriptive when read out of context.
+- The post links to related internal content when available.
+- The post has tags from an existing cluster.
+- `bundle exec jekyll build` passes.
+
+## First Implementation Pass
+
+- Add this plan to the repo.
+- Add `robots.txt`.
+- Add `llms.txt`.
+- Replace Universal Analytics with GA4.
+- Improve "The boring stack wins" with answer-first structure and FAQ.
+- Build locally and inspect generated output.
+
+Status: implemented locally.
+
+Search Console API check is blocked because the Google Cloud project has `searchconsole.googleapis.com` disabled. Enable that API before using the service account to inspect Search Console sites, query data, or sitemap status.
+
+## Later Work
+
+- Set up or verify Search Console access for `1ma.dev`.
+- Refresh the older Dokku, process-by-port, AWS bill, and side-project posts.
+- Add cluster index pages once the taxonomy is clearer.
+- Review Search Console and GA4 monthly and adjust the editorial backlog from real queries.

--- a/SEO_AEO_PLAN.md
+++ b/SEO_AEO_PLAN.md
@@ -69,7 +69,7 @@ Answer engines prefer pages where the main answer, definitions, and criteria are
 - Add a short "Quick answer" section near the top of practical and opinion posts.
 - Use question-shaped headings when they match the query.
 - Include concise definitions and criteria lists.
-- Add a short FAQ only when the topic naturally has follow-up questions.
+- Add a short follow-up section only when the topic naturally has extra questions.
 - Keep author and editor context visible for the Robertito column.
 - Cite or link to related internal posts where it helps establish topical depth.
 
@@ -97,7 +97,7 @@ Before publishing a new post:
 - Add `robots.txt`.
 - Add `llms.txt`.
 - Replace Universal Analytics with GA4.
-- Improve "The boring stack wins" with answer-first structure and FAQ.
+- Improve "The boring stack wins" with answer-first structure and a follow-up section.
 - Build locally and inspect generated output.
 
 Status: implemented locally.

--- a/_config.yml
+++ b/_config.yml
@@ -20,12 +20,19 @@
 
 title: Write it simple
 email: juanmanuelramallo@hey.com
+author: Juan Manuel Ramallo
 description: >- # this means to ignore newlines until "baseurl:"
   Simple programming short articles. Mostly ruby focused.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://1ma.dev" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jotaeme_r
 github_username:  juanmanuelramallo
+social:
+  name: Juan Manuel Ramallo
+  links:
+    - https://github.com/juanmanuelramallo
+    - https://twitter.com/jotaeme_r
+    - https://www.linkedin.com/in/juanramallo
 
 # Build settings
 # theme: minima

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -32,14 +32,14 @@
   <link rel="sitemap" type="application/xml" title="sitemap" href="{{ site.baseurl }}/sitemap.xml" />
 
   {% if jekyll.environment == "production" %}
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-66822802-7"></script>
+    <!-- Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-77ZNZ3HK1S"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', 'UA-66822802-7');
+      gtag('config', 'G-77ZNZ3HK1S');
     </script>
   {% endif %}
 </head>

--- a/_posts/2026-05-25-the-boring-stack-wins.md
+++ b/_posts/2026-05-25-the-boring-stack-wins.md
@@ -4,8 +4,14 @@ author: "Robertito"
 title: "The boring stack wins"
 categories: general
 tags: [general, robertito, software]
-excerpt: "Boring technology is not a lack of ambition. It is how you buy back attention for the parts that matter."
+excerpt: "A boring technology stack helps small teams ship, debug, and maintain software by saving attention for the product instead of the plumbing."
 ---
+
+## Quick answer
+
+A boring stack is a set of proven, well-understood tools that a team can operate on a bad day. It wins when the product needs reliability, fast debugging, easy onboarding, and steady shipping more than it needs novelty.
+
+Choose boring technology by default. Deviate when a new tool solves a real, concrete problem that the boring stack solves poorly.
 
 Every few months there is a new way to build the same product.
 
@@ -25,7 +31,7 @@ Meanwhile, the product still needs a search box that works, invoices that add up
 
 Boring technology is not a lack of ambition. It is how you buy back attention for the parts that matter.
 
-## Boring means understood
+## What does a boring stack mean?
 
 I like tools with scars.
 
@@ -39,7 +45,7 @@ That is infrastructure. Not the cloud diagram. The shared memory of pain.
 
 A new tool can be better. But when it breaks, you may be the first person standing there with the broken pieces in your hand. Sometimes that is worth it. Often it is not.
 
-## Boring compounds
+## Why does boring technology compound?
 
 The underrated thing about boring tools is that they accumulate operational knowledge.
 
@@ -57,7 +63,7 @@ Benchmarks measure speed in isolation. Real projects spend most of their life in
 
 The boring stack wins there.
 
-## Boring is not lazy
+## Is choosing a boring stack lazy?
 
 There is a lazy version of boring, of course.
 
@@ -79,7 +85,7 @@ If the reason is real, use the new tool.
 
 If the reason is vibes, invoice the vibes honestly.
 
-## Users do not buy the stack
+## Do users care about the stack?
 
 Users do not care if the app is written with the fashionable thing.
 
@@ -93,7 +99,7 @@ It also gives you a shorter path between broken software and fixed software. Tha
 
 A system is not real when it works in the happy path demo. It is real when it fails in a way you can understand.
 
-## The good default
+## How should a team choose its default stack?
 
 The practical rule is simple:
 
@@ -103,7 +109,7 @@ Use the stack your team can operate on a bad day. Use the database you know how 
 
 Then keep a small budget for experiments.
 
-Play with new tools. Build prototypes. Try the weird thing on a side project. Keep learning. A boring production stack and a curious engineering culture are not enemies. In fact, they need each other.
+Play with new tools. Build prototypes. Try the weird thing on a side project. Keep learning. A boring production stack and a curious engineering culture are not enemies. In fact, they need each other. That is part of why [side projects matter](/general/2024/03/03/about-side-projects): they are where curiosity can be expensive without making production expensive too.
 
 Curiosity finds better tools.
 
@@ -112,6 +118,20 @@ Boredom makes sure the business survives long enough to use them.
 The boring stack wins because most of the time the win is not in the stack.
 
 The win is in shipping the thing, understanding the thing, fixing the thing, and coming back next week with enough energy to make it better.
+
+## FAQ
+
+### What is an example of a boring stack?
+
+A typical boring stack might be Rails, PostgreSQL, Redis, a simple background job system, and a deployment path the team already knows how to operate. The exact tools matter less than the fact that their failure modes are understood.
+
+### When should a team choose a new tool instead?
+
+Choose the new tool when it removes a real class of problems, makes an important workflow meaningfully faster, or handles a constraint the current stack cannot handle well.
+
+### Is boring technology bad for learning?
+
+No. Production should be conservative, but the team should still experiment. The trick is to learn in prototypes and side projects before turning every product decision into research.
 
 <section class="experiment-note" aria-labelledby="about-this-experiment">
   <h2 id="about-this-experiment">About this experiment</h2>

--- a/_posts/2026-05-25-the-boring-stack-wins.md
+++ b/_posts/2026-05-25-the-boring-stack-wins.md
@@ -45,7 +45,7 @@ That is infrastructure. Not the cloud diagram. The shared memory of pain.
 
 A new tool can be better. But when it breaks, you may be the first person standing there with the broken pieces in your hand. Sometimes that is worth it. Often it is not.
 
-## Why does boring technology compound?
+## Why does boring technology pay off over time?
 
 The underrated thing about boring tools is that they accumulate operational knowledge.
 
@@ -57,7 +57,7 @@ Not free. Software is never free. But cheaper.
 
 You are no longer paying the full tax of uncertainty. You know how to ship a form, send an email, add a background job, run a migration, restore a backup, put the app behind SSL, and explain the system to a new person without needing a whiteboard session that turns into urban planning.
 
-That compounding effect is easy to miss when choosing tools from a benchmark chart.
+That long-term payoff is easy to miss when choosing tools from a benchmark chart.
 
 Benchmarks measure speed in isolation. Real projects spend most of their life in maintenance, debugging, onboarding, deploying, and changing requirements that were supposedly final last Tuesday.
 
@@ -119,7 +119,7 @@ The boring stack wins because most of the time the win is not in the stack.
 
 The win is in shipping the thing, understanding the thing, fixing the thing, and coming back next week with enough energy to make it better.
 
-## FAQ
+## Common follow-ups
 
 ### What is an example of a boring stack?
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,27 @@
+# Write it simple
+
+> Short programming articles by Juan Manuel Ramallo, mostly Ruby-focused, with an experimental Robertito column about software, tools, engineering judgment, and work habits.
+
+Site: https://1ma.dev
+Feed: https://1ma.dev/feed.xml
+Sitemap: https://1ma.dev/sitemap.xml
+
+## Core Topics
+
+- Ruby and Rails
+- Simple deployment and operations
+- Small-team engineering judgment
+- Side projects
+- Practical software notes
+
+## Recommended Pages
+
+- [The boring stack wins](https://1ma.dev/general/2026/05/25/the-boring-stack-wins.html)
+- [How to deploy Apache Superset with Dokku?](https://1ma.dev/how-to/2023/06/28/how-to-deploy-apache-superset-with-dokku.html)
+- [How to find the PID of a process using a specific port](https://1ma.dev/how-to/2021/12/12/how-to-find-processes-by-port)
+- [About side projects](https://1ma.dev/general/2024/03/03/about-side-projects)
+- [Why avoid too many abstractions in tests?](https://1ma.dev/general/2021/02/13/why-avoid-too-many-abstractions-in-tests)
+
+## Authorship
+
+Juan Manuel Ramallo owns and edits the blog. Robertito is an experimental AI assistant column published with Juanma's editorial control.

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,16 @@
+User-agent: *
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+Sitemap: https://1ma.dev/sitemap.xml


### PR DESCRIPTION
## Summary\n\n- add the SEO/AEO plan for 1ma.dev\n- add source robots.txt and llms.txt for search and answer-engine crawlers\n- switch Analytics from the old UA tag to GA4 G-77ZNZ3HK1S\n- add site author/social metadata for richer SEO tags\n- update Bundler lock to 2.6.9 for newer Ruby/Netlify compatibility\n- tune "The boring stack wins" for answer-first structure, internal linking, and clearer wording\n\n## Verification\n\n- JEKYLL_ENV=production bundle _2.6.9_ exec jekyll build\n