### PR TITLE
Refresh blog home and post list design

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,4 +1,4 @@
-<header role="banner" class="sticky top-0 bg-white/90 backdrop-blur-sm shadow-sm">
+<header role="banner" class="site-header sticky top-0 bg-white/90 backdrop-blur-sm shadow-sm">
   <div class="md:container md:mx-auto flex flex-row justify-between py-4 mx-2">
     <div class="sm:flex sm:flex-row sm:gap-10">
       <a href="/">

--- a/_includes/posts.html
+++ b/_includes/posts.html
@@ -1,49 +1,59 @@
 <section class="posts">
   {% if include.title %}
-  <div class="grid md:grid-cols-5 grid-cols-1 md:gap-8 gap-2 mt-8 sm:mt-10">
-    <div class="md:col-span-1 col-span-5"></div>
-    <div class="md:col-span-4 col-span-5">
-      <h1 class="text-3xl font-extrabold tracking-tight text-gray-900 sm:text-4xl xl:mb-8">{{ include.title }}</h1>
-    </div>
+  <div class="posts-heading">
+    <h1>{{ include.title }}</h1>
   </div>
   {% endif %}
-  <ul>
+  <ul class="post-list">
     {% for post in include.posts %}
-      <li class="py-4 mb-4">
-        <div class="grid md:grid-cols-5 grid-cols-1 md:gap-8 gap-2">
-          <div class="md:col-span-1 col-span-5 flex flex-col md:text-right text-center text-sm text-gray">
-            <p class="my-1">
+      <li class="post-list-item">
+        <article class="post-card" data-url="{{ site.baseurl }}{{ post.url }}" role="link" tabindex="0" aria-label="Read {{ post.title | escape }}">
+          <aside class="post-card-meta">
             {% capture tag %}{{ post.tags[0] }}{% endcapture %}
-            {% include tag.html tag=tag %}
-            </p>
-            <p class="mt-2">
+            <div class="post-card-tag">
+              {% include tag.html tag=tag %}
+            </div>
+            <p>
               {% include read_time.html read_time=post.read_time_in_minutes %}
               &middot;
               {% include time.html date=post.date %}
-              {% if post.author %}
-              &middot;
-              <span>By {{ post.author | replace: "Juan Manuel Ramallo", "Juanma" }}</span>
-              {% endif %}
             </p>
-          </div>
-          <div class="md:col-span-4 col-span-5">
-            <h3 class="mb-4 text-xl text-gray-900 md:text-left text-center tracking-tight font-bold hover:text-primary">
-              <a class="" href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>
-            </h3>
-            <p class="prose mb-6">
+          </aside>
+          <div class="post-card-body">
+            <h2>
+              <a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>
+            </h2>
+            <p class="post-card-excerpt">
               {{ post.excerpt | strip_html }}
             </p>
-            <p class="text-center md:text-left">
-              <a class="group inline-flex items-center h-9 rounded-full text-sm whitespace-nowrap px-3 focus:outline-none focus:ring-2 bg-gray-100 text-gray-700 hover:bg-gray-200 focus:ring-gray-500 hover:text-primary hover:fill-primary" href="{{ site.baseurl }}{{ post.url }}">
-                Read more
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 fill-gray-400 group-hover:fill-primary" viewBox="0 0 20 20" fill="currentColor">
-                  <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
-                </svg>
-              </a>
-            </p>
+            <div class="post-card-footer">
+              {% if post.author %}
+                <span>By {{ post.author | replace: "Juan Manuel Ramallo", "Juanma" }}</span>
+              {% endif %}
+            </div>
           </div>
-        </div>
+        </article>
       </li>
     {% endfor %}
   </ul>
 </section>
+
+<script>
+  (function () {
+    var cards = document.querySelectorAll('.post-card[data-url]');
+
+    cards.forEach(function (card) {
+      card.addEventListener('click', function (event) {
+        if (event.target.closest('a')) return;
+        window.location.href = card.dataset.url;
+      });
+
+      card.addEventListener('keydown', function (event) {
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        if (event.target.closest('a')) return;
+        event.preventDefault();
+        window.location.href = card.dataset.url;
+      });
+    });
+  })();
+</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,10 +5,10 @@ layout: compress
 <!DOCTYPE html>
 <html lang="en" >
   {% include head.html %}
-  <body class="min-h-screen flex flex-col justify-between transition-all ease-in-out delay-200">
+  <body class="min-h-screen flex flex-col justify-between transition-all ease-in-out delay-200{% if page.url == "/" %} home-page{% endif %}">
     <main role="main" class="">
       {% include navigation.html %}
-      <div class="md:container md:mx-auto mx-2">
+      <div class="site-shell">
         {{ content }}
       </div>
     </main>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -20,9 +20,9 @@ layout: default
     {{ content }}
   </div>
 
-  <div class="flex flex-row">
+  <div class="post-tags">
     {% for tag in page.tags %}
-    <p class="mr-2">
+    <p>
       {% include tag.html tag=tag %}
     </p>
     {% endfor %}

--- a/assets/main.css
+++ b/assets/main.css
@@ -387,17 +387,6 @@ Ensure the default browser behavior of the `hidden` attribute.
   --tw-shadow-colored: 0 0 #0000;
 }
 
-.focus\:ring-2 {
-  --tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
-  --tw-ring-offset-width: 0px;
-  --tw-ring-offset-color: #fff;
-  --tw-ring-color: rgb(59 130 246 / 0.5);
-  --tw-ring-offset-shadow: 0 0 #0000;
-  --tw-ring-shadow: 0 0 #0000;
-  --tw-shadow: 0 0 #0000;
-  --tw-shadow-colored: 0 0 #0000;
-}
-
 .backdrop-blur-sm {
   --tw-backdrop-blur: var(--tw-empty,/*!*/ /*!*/);
   --tw-backdrop-brightness: var(--tw-empty,/*!*/ /*!*/);
@@ -790,9 +779,6 @@ Ensure the default browser behavior of the `hidden` attribute.
 .top-0 {
   top: 0px;
 }
-.col-span-5 {
-  grid-column: span 5 / span 5;
-}
 .mx-2 {
   margin-left: 0.5rem;
   margin-right: 0.5rem;
@@ -805,10 +791,6 @@ Ensure the default browser behavior of the `hidden` attribute.
   margin-left: auto;
   margin-right: auto;
 }
-.my-1 {
-  margin-top: 0.25rem;
-  margin-bottom: 0.25rem;
-}
 .my-6 {
   margin-top: 1.5rem;
   margin-bottom: 1.5rem;
@@ -816,20 +798,14 @@ Ensure the default browser behavior of the `hidden` attribute.
 .mt-6 {
   margin-top: 1.5rem;
 }
-.mb-4 {
-  margin-bottom: 1rem;
+.mb-3 {
+  margin-bottom: 0.75rem;
 }
 .mt-2 {
   margin-top: 0.5rem;
 }
 .mb-6 {
   margin-bottom: 1.5rem;
-}
-.mt-8 {
-  margin-top: 2rem;
-}
-.mb-3 {
-  margin-bottom: 0.75rem;
 }
 .mr-2 {
   margin-right: 0.5rem;
@@ -840,14 +816,8 @@ Ensure the default browser behavior of the `hidden` attribute.
 .flex {
   display: flex;
 }
-.inline-flex {
-  display: inline-flex;
-}
 .table {
   display: table;
-}
-.grid {
-  display: grid;
 }
 .h-full {
   height: 100%;
@@ -855,20 +825,11 @@ Ensure the default browser behavior of the `hidden` attribute.
 .h-10 {
   height: 2.5rem;
 }
-.h-9 {
-  height: 2.25rem;
-}
-.h-5 {
-  height: 1.25rem;
-}
 .min-h-screen {
   min-height: 100vh;
 }
-.w-5 {
-  width: 1.25rem;
-}
-.grid-cols-1 {
-  grid-template-columns: repeat(1, minmax(0, 1fr));
+.resize {
+  resize: both;
 }
 .flex-row {
   flex-direction: row;
@@ -876,17 +837,11 @@ Ensure the default browser behavior of the `hidden` attribute.
 .flex-col {
   flex-direction: column;
 }
-.items-center {
-  align-items: center;
-}
 .justify-between {
   justify-content: space-between;
 }
 .gap-2 {
   gap: 0.5rem;
-}
-.whitespace-nowrap {
-  white-space: nowrap;
 }
 .rounded-full {
   border-radius: 9999px;
@@ -929,9 +884,6 @@ Ensure the default browser behavior of the `hidden` attribute.
 .bg-repeat {
   background-repeat: repeat;
 }
-.fill-gray-400 {
-  fill: #9ca3af;
-}
 .p-12 {
   padding: 3rem;
 }
@@ -954,9 +906,6 @@ Ensure the default browser behavior of the `hidden` attribute.
 .text-left {
   text-align: left;
 }
-.text-center {
-  text-align: center;
-}
 .text-4xl {
   font-size: 2.25rem;
   line-height: 2.5rem;
@@ -965,19 +914,12 @@ Ensure the default browser behavior of the `hidden` attribute.
   font-size: 0.875rem;
   line-height: 1.25rem;
 }
-.text-xl {
-  font-size: 1.25rem;
-  line-height: 1.75rem;
-}
 .text-3xl {
   font-size: 1.875rem;
   line-height: 2.25rem;
 }
 .font-extrabold {
   font-weight: 800;
-}
-.font-bold {
-  font-weight: 700;
 }
 .tracking-tight {
   letter-spacing: -0.025em;
@@ -988,10 +930,6 @@ Ensure the default browser behavior of the `hidden` attribute.
 .text-gray-900 {
   --tw-text-opacity: 1;
   color: rgb(17 24 39 / var(--tw-text-opacity));
-}
-.text-gray-700 {
-  --tw-text-opacity: 1;
-  color: rgb(55 65 81 / var(--tw-text-opacity));
 }
 .shadow-sm {
   --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
@@ -1015,12 +953,262 @@ Ensure the default browser behavior of the `hidden` attribute.
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
+:root {
+  --site-bg: #fbfaf7;
+  --site-ink: #171717;
+  --site-muted: #5f6368;
+  --site-soft: #ece7dd;
+  --site-accent: #0f6b8c;
+  --site-accent-soft: #dff3f8;
+}
+
+html {
+  text-rendering: optimizeLegibility;
+}
+
+body {
+  background: var(--site-bg);
+  color: var(--site-ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 17px;
+  letter-spacing: 0;
+}
+
+::-moz-selection {
+  background: var(--site-accent-soft);
+}
+
+::selection {
+  background: var(--site-accent-soft);
+}
+
+.site-shell {
+  width: min(100% - 2rem, 980px);
+  margin-inline: auto;
+}
+
+.home-page.home-header-ready .site-header {
+  left: 0;
+  opacity: 0;
+  pointer-events: none;
+  position: fixed;
+  right: 0;
+  top: 0;
+  transform: translateY(-100%);
+  transition: opacity 160ms ease, transform 180ms ease;
+  z-index: 50;
+}
+
+.home-page.home-header-ready .site-header.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.home-intro {
+  max-width: 780px;
+  padding: 4.75rem 0 3.25rem;
+}
+
+.home-kicker {
+  color: var(--site-accent);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  margin-bottom: 1rem;
+  text-transform: uppercase;
+}
+
+.home-intro h1 {
+  color: var(--site-ink);
+  font-size: clamp(2.35rem, 5vw, 4.9rem);
+  font-weight: 800;
+  letter-spacing: 0;
+  line-height: 0.96;
+  max-width: 11.5em;
+}
+
+.home-lede {
+  color: var(--site-muted);
+  font-size: 1.12rem;
+  line-height: 1.75;
+  margin-top: 1.35rem;
+  max-width: 42rem;
+}
+
+.home-topics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  margin-top: 1.65rem;
+}
+
+.home-topics a {
+  border: 1px solid var(--site-soft);
+  border-radius: 999px;
+  color: #33312d;
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1;
+  padding: 0.62rem 0.85rem;
+  transition: border-color 140ms ease, color 140ms ease, background 140ms ease;
+}
+
+.home-topics a:hover,
+.home-topics a:focus-visible {
+  background: #fff;
+  border-color: #cfc6b8;
+  color: var(--site-accent);
+}
+
+.posts {
+  padding-bottom: 4rem;
+}
+
+.posts-heading {
+  border-top: 1px solid var(--site-soft);
+  padding-top: 2rem;
+}
+
+.posts-heading h1 {
+  font-size: 2.25rem;
+  font-weight: 800;
+  line-height: 1.05;
+}
+
+.post-list {
+  border-top: 1px solid var(--site-soft);
+}
+
+.post-list-item {
+  border-bottom: 1px solid var(--site-soft);
+}
+
+.post-card {
+  cursor: pointer;
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: minmax(9rem, 0.9fr) minmax(0, 4fr);
+  margin-inline: -1rem;
+  padding: 2.35rem 1rem;
+  transition: background 150ms ease;
+}
+
+.post-card:hover,
+.post-card:focus-visible {
+  background: rgba(255, 255, 255, 0.42);
+  outline: none;
+}
+
+.post-card:hover .post-card-body h2 a,
+.post-card:focus-visible .post-card-body h2 a {
+  color: var(--site-accent);
+}
+
+.post-card-meta {
+  color: var(--site-muted);
+  font-size: 0.82rem;
+  line-height: 1.55;
+  padding-top: 0.2rem;
+  text-align: right;
+}
+
+.post-card-tag {
+  margin-bottom: 0.7rem;
+}
+
+.post-card-tag a {
+  background: transparent;
+  border: 1px solid var(--site-soft);
+  color: var(--site-accent);
+}
+
+.post-card-body h2 {
+  color: var(--site-ink);
+  font-size: clamp(1.65rem, 3vw, 2.35rem);
+  font-weight: 800;
+  letter-spacing: 0;
+  line-height: 1.08;
+  max-width: 13em;
+}
+
+.post-card-body h2 a {
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.16em;
+  transition: color 140ms ease, -webkit-text-decoration-color 140ms ease;
+  transition: color 140ms ease, text-decoration-color 140ms ease;
+  transition: color 140ms ease, text-decoration-color 140ms ease, -webkit-text-decoration-color 140ms ease;
+}
+
+.post-card-body h2 a:hover,
+.post-card-body h2 a:focus-visible {
+  color: var(--site-accent);
+  text-decoration: underline;
+  -webkit-text-decoration-color: #8fc8d7;
+          text-decoration-color: #8fc8d7;
+}
+
+.post-card-excerpt {
+  color: #3f3f3f;
+  font-size: 1.03rem;
+  line-height: 1.78;
+  margin-top: 1rem;
+  max-width: 42rem;
+}
+
+.post-card-footer {
+  align-items: center;
+  color: var(--site-muted);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 0.88rem;
+  gap: 0.8rem;
+  margin-top: 1.2rem;
+}
+
 .piano-pattern {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='70' height='46' viewBox='0 0 70 46'%3E%3Cg fill-rule='evenodd'%3E%3Cg fill='%23f8fafc' fill-opacity='0.5'%3E%3Cpolygon points='68 44 62 44 62 46 56 46 56 44 52 44 52 46 46 46 46 44 40 44 40 46 38 46 38 44 32 44 32 46 26 46 26 44 22 44 22 46 16 46 16 44 12 44 12 46 6 46 6 44 0 44 0 42 8 42 8 28 6 28 6 0 12 0 12 28 10 28 10 42 18 42 18 28 16 28 16 0 22 0 22 28 20 28 20 42 28 42 28 28 26 28 26 0 32 0 32 28 30 28 30 42 38 42 38 0 40 0 40 42 48 42 48 28 46 28 46 0 52 0 52 28 50 28 50 42 58 42 58 28 56 28 56 0 62 0 62 28 60 28 60 42 68 42 68 0 70 0 70 46 68 46'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")
 }
 
+.prose {
+  font-size: 1.06rem;
+  line-height: 1.78;
+  max-width: 68ch;
+}
+
 .prose a:hover {
   color: #0369a1;
+}
+
+.prose p,
+.prose ul,
+.prose ol {
+  margin-top: 1.15em;
+  margin-bottom: 1.15em;
+}
+
+.prose h2 {
+  letter-spacing: 0;
+}
+
+.post-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  max-width: 100%;
+}
+
+.post-tags p {
+  margin: 0;
+}
+
+.post-tags a {
+  display: inline-flex;
+  max-width: 100%;
+}
+
+.post-tags .post-tag {
+  overflow-wrap: anywhere;
 }
 
 .experiment-note {
@@ -1048,9 +1236,44 @@ Ensure the default browser behavior of the `hidden` attribute.
   margin-top: 0.75rem;
 }
 
-.hover\:bg-gray-200:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(229 231 235 / var(--tw-bg-opacity));
+@media (max-width: 767px) {
+  body {
+    font-size: 16px;
+  }
+
+  .site-shell {
+    width: min(100% - 1.25rem, 980px);
+  }
+
+  .home-intro {
+    padding: 3rem 0 2.25rem;
+  }
+
+  .home-intro h1 {
+    font-size: 2.55rem;
+    line-height: 1;
+  }
+
+  .post-card {
+    gap: 0.95rem;
+    grid-template-columns: 1fr;
+    padding: 1.8rem 0;
+  }
+
+  .post-card-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.7rem;
+    text-align: left;
+  }
+
+  .post-card-tag {
+    margin-bottom: 0;
+  }
+
+  .post-card-body h2 {
+    max-width: 100%;
+  }
 }
 
 .hover\:from-sky-400:hover {
@@ -1062,40 +1285,12 @@ Ensure the default browser behavior of the `hidden` attribute.
   --tw-gradient-to: #fbbf24;
 }
 
-.hover\:fill-primary:hover {
-  fill: #0369a1;
-}
-
 .hover\:text-primary:hover {
   --tw-text-opacity: 1;
   color: rgb(3 105 161 / var(--tw-text-opacity));
 }
 
-.focus\:outline-none:focus {
-  outline: 2px solid transparent;
-  outline-offset: 2px;
-}
-
-.focus\:ring-2:focus {
-  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
-  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
-  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
-}
-
-.focus\:ring-gray-500:focus {
-  --tw-ring-opacity: 1;
-  --tw-ring-color: rgb(107 114 128 / var(--tw-ring-opacity));
-}
-
-.group:hover .group-hover\:fill-primary {
-  fill: #0369a1;
-}
-
 @media (min-width: 640px) {
-
-  .sm\:mt-10 {
-    margin-top: 2.5rem;
-  }
 
   .sm\:block {
     display: block;
@@ -1165,33 +1360,9 @@ Ensure the default browser behavior of the `hidden` attribute.
     }
   }
 
-  .md\:col-span-1 {
-    grid-column: span 1 / span 1;
-  }
-
-  .md\:col-span-4 {
-    grid-column: span 4 / span 4;
-  }
-
   .md\:mx-auto {
     margin-left: auto;
     margin-right: auto;
-  }
-
-  .md\:grid-cols-5 {
-    grid-template-columns: repeat(5, minmax(0, 1fr));
-  }
-
-  .md\:gap-8 {
-    gap: 2rem;
-  }
-
-  .md\:text-left {
-    text-align: left;
-  }
-
-  .md\:text-right {
-    text-align: right;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -2,4 +2,40 @@
 layout: default
 ---
 
+<section class="home-intro" aria-labelledby="home-intro-title">
+  <p class="home-kicker">Write it simple</p>
+  <h1 id="home-intro-title">Short essays on software, side projects, and useful mistakes.</h1>
+  <p class="home-lede">
+    Notes from building things in public and in production: Ruby, Rails, operations,
+    pragmatic engineering, and the occasional field report from Robertito.
+  </p>
+  <div class="home-topics" aria-label="Featured topics">
+    <a href="/tag/software">Software</a>
+    <a href="/tag/ruby">Ruby</a>
+    <a href="/tag/rails">Rails</a>
+    <a href="/tag/anecdote">Anecdotes</a>
+  </div>
+</section>
+
 {% include posts.html posts=site.posts %}
+
+<script>
+  (function () {
+    var header = document.querySelector('.site-header');
+    var intro = document.querySelector('.home-intro');
+
+    if (!header || !intro) return;
+
+    document.body.classList.add('home-header-ready');
+
+    function updateHeaderVisibility() {
+      var introBottom = intro.offsetTop + intro.offsetHeight;
+      var threshold = Math.max(window.innerHeight * 0.78, introBottom - 32);
+      header.classList.toggle('is-visible', window.scrollY > threshold);
+    }
+
+    updateHeaderVisibility();
+    window.addEventListener('scroll', updateHeaderVisibility, { passive: true });
+    window.addEventListener('resize', updateHeaderVisibility);
+  })();
+</script>

--- a/main.css
+++ b/main.css
@@ -2,12 +2,255 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --site-bg: #fbfaf7;
+  --site-ink: #171717;
+  --site-muted: #5f6368;
+  --site-soft: #ece7dd;
+  --site-accent: #0f6b8c;
+  --site-accent-soft: #dff3f8;
+}
+
+html {
+  text-rendering: optimizeLegibility;
+}
+
+body {
+  background: var(--site-bg);
+  color: var(--site-ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 17px;
+  letter-spacing: 0;
+}
+
+::selection {
+  background: var(--site-accent-soft);
+}
+
+.site-shell {
+  width: min(100% - 2rem, 980px);
+  margin-inline: auto;
+}
+
+.home-page.home-header-ready .site-header {
+  left: 0;
+  opacity: 0;
+  pointer-events: none;
+  position: fixed;
+  right: 0;
+  top: 0;
+  transform: translateY(-100%);
+  transition: opacity 160ms ease, transform 180ms ease;
+  z-index: 50;
+}
+
+.home-page.home-header-ready .site-header.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.home-intro {
+  max-width: 780px;
+  padding: 4.75rem 0 3.25rem;
+}
+
+.home-kicker {
+  color: var(--site-accent);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  margin-bottom: 1rem;
+  text-transform: uppercase;
+}
+
+.home-intro h1 {
+  color: var(--site-ink);
+  font-size: clamp(2.35rem, 5vw, 4.9rem);
+  font-weight: 800;
+  letter-spacing: 0;
+  line-height: 0.96;
+  max-width: 11.5em;
+}
+
+.home-lede {
+  color: var(--site-muted);
+  font-size: 1.12rem;
+  line-height: 1.75;
+  margin-top: 1.35rem;
+  max-width: 42rem;
+}
+
+.home-topics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  margin-top: 1.65rem;
+}
+
+.home-topics a {
+  border: 1px solid var(--site-soft);
+  border-radius: 999px;
+  color: #33312d;
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1;
+  padding: 0.62rem 0.85rem;
+  transition: border-color 140ms ease, color 140ms ease, background 140ms ease;
+}
+
+.home-topics a:hover,
+.home-topics a:focus-visible {
+  background: #fff;
+  border-color: #cfc6b8;
+  color: var(--site-accent);
+}
+
+.posts {
+  padding-bottom: 4rem;
+}
+
+.posts-heading {
+  border-top: 1px solid var(--site-soft);
+  padding-top: 2rem;
+}
+
+.posts-heading h1 {
+  font-size: 2.25rem;
+  font-weight: 800;
+  line-height: 1.05;
+}
+
+.post-list {
+  border-top: 1px solid var(--site-soft);
+}
+
+.post-list-item {
+  border-bottom: 1px solid var(--site-soft);
+}
+
+.post-card {
+  cursor: pointer;
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: minmax(9rem, 0.9fr) minmax(0, 4fr);
+  margin-inline: -1rem;
+  padding: 2.35rem 1rem;
+  transition: background 150ms ease;
+}
+
+.post-card:hover,
+.post-card:focus-visible {
+  background: rgba(255, 255, 255, 0.42);
+  outline: none;
+}
+
+.post-card:hover .post-card-body h2 a,
+.post-card:focus-visible .post-card-body h2 a {
+  color: var(--site-accent);
+}
+
+.post-card-meta {
+  color: var(--site-muted);
+  font-size: 0.82rem;
+  line-height: 1.55;
+  padding-top: 0.2rem;
+  text-align: right;
+}
+
+.post-card-tag {
+  margin-bottom: 0.7rem;
+}
+
+.post-card-tag a {
+  background: transparent;
+  border: 1px solid var(--site-soft);
+  color: var(--site-accent);
+}
+
+.post-card-body h2 {
+  color: var(--site-ink);
+  font-size: clamp(1.65rem, 3vw, 2.35rem);
+  font-weight: 800;
+  letter-spacing: 0;
+  line-height: 1.08;
+  max-width: 13em;
+}
+
+.post-card-body h2 a {
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.16em;
+  transition: color 140ms ease, text-decoration-color 140ms ease;
+}
+
+.post-card-body h2 a:hover,
+.post-card-body h2 a:focus-visible {
+  color: var(--site-accent);
+  text-decoration: underline;
+  text-decoration-color: #8fc8d7;
+}
+
+.post-card-excerpt {
+  color: #3f3f3f;
+  font-size: 1.03rem;
+  line-height: 1.78;
+  margin-top: 1rem;
+  max-width: 42rem;
+}
+
+.post-card-footer {
+  align-items: center;
+  color: var(--site-muted);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 0.88rem;
+  gap: 0.8rem;
+  margin-top: 1.2rem;
+}
+
 .piano-pattern {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='70' height='46' viewBox='0 0 70 46'%3E%3Cg fill-rule='evenodd'%3E%3Cg fill='%23f8fafc' fill-opacity='0.5'%3E%3Cpolygon points='68 44 62 44 62 46 56 46 56 44 52 44 52 46 46 46 46 44 40 44 40 46 38 46 38 44 32 44 32 46 26 46 26 44 22 44 22 46 16 46 16 44 12 44 12 46 6 46 6 44 0 44 0 42 8 42 8 28 6 28 6 0 12 0 12 28 10 28 10 42 18 42 18 28 16 28 16 0 22 0 22 28 20 28 20 42 28 42 28 28 26 28 26 0 32 0 32 28 30 28 30 42 38 42 38 0 40 0 40 42 48 42 48 28 46 28 46 0 52 0 52 28 50 28 50 42 58 42 58 28 56 28 56 0 62 0 62 28 60 28 60 42 68 42 68 0 70 0 70 46 68 46'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")
 }
 
+.prose {
+  font-size: 1.06rem;
+  line-height: 1.78;
+  max-width: 68ch;
+}
+
 .prose a:hover {
   color: #0369a1;
+}
+
+.prose p,
+.prose ul,
+.prose ol {
+  margin-top: 1.15em;
+  margin-bottom: 1.15em;
+}
+
+.prose h2 {
+  letter-spacing: 0;
+}
+
+.post-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  max-width: 100%;
+}
+
+.post-tags p {
+  margin: 0;
+}
+
+.post-tags a {
+  display: inline-flex;
+  max-width: 100%;
+}
+
+.post-tags .post-tag {
+  overflow-wrap: anywhere;
 }
 
 .experiment-note {
@@ -33,4 +276,44 @@
 
 .experiment-note p + p {
   margin-top: 0.75rem;
+}
+
+@media (max-width: 767px) {
+  body {
+    font-size: 16px;
+  }
+
+  .site-shell {
+    width: min(100% - 1.25rem, 980px);
+  }
+
+  .home-intro {
+    padding: 3rem 0 2.25rem;
+  }
+
+  .home-intro h1 {
+    font-size: 2.55rem;
+    line-height: 1;
+  }
+
+  .post-card {
+    gap: 0.95rem;
+    grid-template-columns: 1fr;
+    padding: 1.8rem 0;
+  }
+
+  .post-card-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.7rem;
+    text-align: left;
+  }
+
+  .post-card-tag {
+    margin-bottom: 0;
+  }
+
+  .post-card-body h2 {
+    max-width: 100%;
+  }
 }


### PR DESCRIPTION
## Summary
- Add an editorial intro to the home page with topic shortcuts
- Restyle the post index with wider spacing, clearer typography, full-row click targets, and subtler hover states
- Keep the home header hidden until the reader scrolls past the intro
- Fix post tag wrapping on mobile to prevent horizontal scroll

## Verification
- `npm run build`
- `bundle _2.6.9_ exec jekyll build`
- Preview: http://clawdbot.toro.home/artifacts/blog/design-refresh-20260528/
