### PR TITLE
Refresh blog post reading layout

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,9 +2,9 @@
 layout: default
 ---
 
-<section class="post my-6" id="post">
-  <div class="text-left mb-3">
-    <p class="text-sm">
+<section class="post-page" id="post">
+  <header class="post-header">
+    <p class="post-meta">
       {% include time.html date=page.date %}
       &middot;
       {% include read_time.html read_time=page.read_time_in_minutes %}
@@ -13,10 +13,17 @@ layout: default
       <span>By {{ page.author | replace: "Juan Manuel Ramallo", "Juanma" }}</span>
       {% endif %}
     </p>
-    <h1 class="text-3xl mt-2 font-extrabold tracking-tight text-gray-900 sm:text-4xl xl:mb-8">{{ page.title }}</h1>
-  </div>
 
-  <div class="prose mb-6">
+    <h1>{{ page.title }}</h1>
+
+    {% assign post_excerpt = page.excerpt | strip_html | strip %}
+    {% if post_excerpt != "" %}
+      <p class="post-dek">{{ post_excerpt }}</p>
+    {% endif %}
+
+  </header>
+
+  <div class="post-content prose">
     {{ content }}
   </div>
 
@@ -27,4 +34,58 @@ layout: default
     </p>
     {% endfor %}
   </div>
+
+  {% if page.previous or page.next %}
+    <nav class="post-nav" aria-label="Post navigation">
+      {% if page.previous %}
+        <a class="post-nav-item" href="{{ site.baseurl }}{{ page.previous.url }}">
+          <span>Previous</span>
+          <strong>{{ page.previous.title }}</strong>
+        </a>
+      {% endif %}
+      {% if page.next %}
+        <a class="post-nav-item" href="{{ site.baseurl }}{{ page.next.url }}">
+          <span>Next</span>
+          <strong>{{ page.next.title }}</strong>
+        </a>
+      {% endif %}
+    </nav>
+  {% endif %}
+
+  {% assign related_count = 0 %}
+  {% capture related_items %}
+    {% for post in site.posts %}
+      {% unless post.url == page.url %}
+        {% assign has_related_tag = false %}
+        {% for tag in page.tags %}
+          {% if post.tags contains tag %}
+            {% assign has_related_tag = true %}
+          {% endif %}
+        {% endfor %}
+        {% if has_related_tag and related_count < 3 %}
+          {% assign related_count = related_count | plus: 1 %}
+          <li>
+            <a href="{{ site.baseurl }}{{ post.url }}">
+              <span>
+                {% include time.html date=post.date %}
+                {% if post.tags[0] %}
+                  &middot; #{{ post.tags[0] }}
+                {% endif %}
+              </span>
+              <strong>{{ post.title }}</strong>
+            </a>
+          </li>
+        {% endif %}
+      {% endunless %}
+    {% endfor %}
+  {% endcapture %}
+
+  {% if related_count > 0 %}
+    <section class="related-posts" aria-labelledby="related-posts-title">
+      <h2 id="related-posts-title">Related posts</h2>
+      <ul>
+        {{ related_items }}
+      </ul>
+    </section>
+  {% endif %}
 </section>

--- a/assets/main.css
+++ b/assets/main.css
@@ -791,24 +791,8 @@ Ensure the default browser behavior of the `hidden` attribute.
   margin-left: auto;
   margin-right: auto;
 }
-.my-6 {
-  margin-top: 1.5rem;
-  margin-bottom: 1.5rem;
-}
 .mt-6 {
   margin-top: 1.5rem;
-}
-.mb-3 {
-  margin-bottom: 0.75rem;
-}
-.mt-2 {
-  margin-top: 0.5rem;
-}
-.mb-6 {
-  margin-bottom: 1.5rem;
-}
-.mr-2 {
-  margin-right: 0.5rem;
 }
 .inline {
   display: inline;
@@ -903,33 +887,15 @@ Ensure the default browser behavior of the `hidden` attribute.
   padding-left: 0.75rem;
   padding-right: 0.75rem;
 }
-.text-left {
-  text-align: left;
-}
 .text-4xl {
   font-size: 2.25rem;
   line-height: 2.5rem;
 }
-.text-sm {
-  font-size: 0.875rem;
-  line-height: 1.25rem;
-}
-.text-3xl {
-  font-size: 1.875rem;
-  line-height: 2.25rem;
-}
 .font-extrabold {
   font-weight: 800;
 }
-.tracking-tight {
-  letter-spacing: -0.025em;
-}
 .text-transparent {
   color: transparent;
-}
-.text-gray-900 {
-  --tw-text-opacity: 1;
-  color: rgb(17 24 39 / var(--tw-text-opacity));
 }
 .shadow-sm {
   --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
@@ -1170,6 +1136,45 @@ body {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='70' height='46' viewBox='0 0 70 46'%3E%3Cg fill-rule='evenodd'%3E%3Cg fill='%23f8fafc' fill-opacity='0.5'%3E%3Cpolygon points='68 44 62 44 62 46 56 46 56 44 52 44 52 46 46 46 46 44 40 44 40 46 38 46 38 44 32 44 32 46 26 46 26 44 22 44 22 46 16 46 16 44 12 44 12 46 6 46 6 44 0 44 0 42 8 42 8 28 6 28 6 0 12 0 12 28 10 28 10 42 18 42 18 28 16 28 16 0 22 0 22 28 20 28 20 42 28 42 28 28 26 28 26 0 32 0 32 28 30 28 30 42 38 42 38 0 40 0 40 42 48 42 48 28 46 28 46 0 52 0 52 28 50 28 50 42 58 42 58 28 56 28 56 0 62 0 62 28 60 28 60 42 68 42 68 0 70 0 70 46 68 46'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")
 }
 
+.post-page {
+  padding: 3.5rem 0 4.5rem;
+}
+
+.post-header {
+  border-bottom: 1px solid var(--site-soft);
+  margin-bottom: 2.75rem;
+  max-width: 760px;
+  padding-bottom: 2rem;
+}
+
+.post-meta {
+  color: var(--site-muted);
+  font-size: 0.88rem;
+  line-height: 1.6;
+}
+
+.post-header h1 {
+  color: var(--site-ink);
+  font-size: clamp(2.25rem, 5vw, 4.75rem);
+  font-weight: 800;
+  letter-spacing: 0;
+  line-height: 1;
+  margin-top: 0.85rem;
+  max-width: 11em;
+}
+
+.post-dek {
+  color: #464646;
+  font-size: clamp(1.12rem, 2vw, 1.34rem);
+  line-height: 1.65;
+  margin-top: 1.15rem;
+  max-width: 42rem;
+}
+
+.post-content {
+  margin-bottom: 3.5rem;
+}
+
 .prose {
   font-size: 1.06rem;
   line-height: 1.78;
@@ -1195,6 +1200,7 @@ body {
   display: flex;
   flex-wrap: wrap;
   gap: 0.65rem;
+  margin-top: 1.35rem;
   max-width: 100%;
 }
 
@@ -1209,6 +1215,75 @@ body {
 
 .post-tags .post-tag {
   overflow-wrap: anywhere;
+}
+
+.post-nav {
+  border-bottom: 1px solid var(--site-soft);
+  border-top: 1px solid var(--site-soft);
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: 3rem;
+  padding: 1.25rem 0;
+}
+
+.post-nav-item {
+  padding: 0.85rem 0;
+}
+
+.post-nav-item span,
+.related-posts span {
+  color: var(--site-muted);
+  display: block;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  margin-bottom: 0.35rem;
+  text-transform: uppercase;
+}
+
+.post-nav-item strong,
+.related-posts strong {
+  color: var(--site-ink);
+  display: block;
+  font-size: 1.05rem;
+  line-height: 1.35;
+  transition: color 140ms ease;
+}
+
+.post-nav-item:hover strong,
+.post-nav-item:focus-visible strong,
+.related-posts a:hover strong,
+.related-posts a:focus-visible strong {
+  color: var(--site-accent);
+}
+
+.related-posts {
+  margin-top: 3rem;
+  width: 100%;
+}
+
+.related-posts h2 {
+  color: var(--site-ink);
+  font-size: 1.35rem;
+  font-weight: 800;
+  line-height: 1.2;
+}
+
+.related-posts ul {
+  margin-top: 1rem;
+}
+
+.related-posts li {
+  border-top: 1px solid var(--site-soft);
+}
+
+.related-posts li:last-child {
+  border-bottom: 1px solid var(--site-soft);
+}
+
+.related-posts a {
+  display: block;
+  padding: 1rem 0;
 }
 
 .experiment-note {
@@ -1274,6 +1349,14 @@ body {
   .post-card-body h2 {
     max-width: 100%;
   }
+
+  .post-page {
+    padding-top: 2.5rem;
+  }
+
+  .post-nav {
+    grid-template-columns: 1fr;
+  }
 }
 
 .hover\:from-sky-400:hover {
@@ -1311,11 +1394,6 @@ body {
   .sm\:px-4 {
     padding-left: 1rem;
     padding-right: 1rem;
-  }
-
-  .sm\:text-4xl {
-    font-size: 2.25rem;
-    line-height: 2.5rem;
   }
 }
 
@@ -1363,12 +1441,5 @@ body {
   .md\:mx-auto {
     margin-left: auto;
     margin-right: auto;
-  }
-}
-
-@media (min-width: 1280px) {
-
-  .xl\:mb-8 {
-    margin-bottom: 2rem;
   }
 }

--- a/main.css
+++ b/main.css
@@ -212,6 +212,45 @@ body {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='70' height='46' viewBox='0 0 70 46'%3E%3Cg fill-rule='evenodd'%3E%3Cg fill='%23f8fafc' fill-opacity='0.5'%3E%3Cpolygon points='68 44 62 44 62 46 56 46 56 44 52 44 52 46 46 46 46 44 40 44 40 46 38 46 38 44 32 44 32 46 26 46 26 44 22 44 22 46 16 46 16 44 12 44 12 46 6 46 6 44 0 44 0 42 8 42 8 28 6 28 6 0 12 0 12 28 10 28 10 42 18 42 18 28 16 28 16 0 22 0 22 28 20 28 20 42 28 42 28 28 26 28 26 0 32 0 32 28 30 28 30 42 38 42 38 0 40 0 40 42 48 42 48 28 46 28 46 0 52 0 52 28 50 28 50 42 58 42 58 28 56 28 56 0 62 0 62 28 60 28 60 42 68 42 68 0 70 0 70 46 68 46'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")
 }
 
+.post-page {
+  padding: 3.5rem 0 4.5rem;
+}
+
+.post-header {
+  border-bottom: 1px solid var(--site-soft);
+  margin-bottom: 2.75rem;
+  max-width: 760px;
+  padding-bottom: 2rem;
+}
+
+.post-meta {
+  color: var(--site-muted);
+  font-size: 0.88rem;
+  line-height: 1.6;
+}
+
+.post-header h1 {
+  color: var(--site-ink);
+  font-size: clamp(2.25rem, 5vw, 4.75rem);
+  font-weight: 800;
+  letter-spacing: 0;
+  line-height: 1;
+  margin-top: 0.85rem;
+  max-width: 11em;
+}
+
+.post-dek {
+  color: #464646;
+  font-size: clamp(1.12rem, 2vw, 1.34rem);
+  line-height: 1.65;
+  margin-top: 1.15rem;
+  max-width: 42rem;
+}
+
+.post-content {
+  margin-bottom: 3.5rem;
+}
+
 .prose {
   font-size: 1.06rem;
   line-height: 1.78;
@@ -237,6 +276,7 @@ body {
   display: flex;
   flex-wrap: wrap;
   gap: 0.65rem;
+  margin-top: 1.35rem;
   max-width: 100%;
 }
 
@@ -251,6 +291,75 @@ body {
 
 .post-tags .post-tag {
   overflow-wrap: anywhere;
+}
+
+.post-nav {
+  border-bottom: 1px solid var(--site-soft);
+  border-top: 1px solid var(--site-soft);
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: 3rem;
+  padding: 1.25rem 0;
+}
+
+.post-nav-item {
+  padding: 0.85rem 0;
+}
+
+.post-nav-item span,
+.related-posts span {
+  color: var(--site-muted);
+  display: block;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  margin-bottom: 0.35rem;
+  text-transform: uppercase;
+}
+
+.post-nav-item strong,
+.related-posts strong {
+  color: var(--site-ink);
+  display: block;
+  font-size: 1.05rem;
+  line-height: 1.35;
+  transition: color 140ms ease;
+}
+
+.post-nav-item:hover strong,
+.post-nav-item:focus-visible strong,
+.related-posts a:hover strong,
+.related-posts a:focus-visible strong {
+  color: var(--site-accent);
+}
+
+.related-posts {
+  margin-top: 3rem;
+  width: 100%;
+}
+
+.related-posts h2 {
+  color: var(--site-ink);
+  font-size: 1.35rem;
+  font-weight: 800;
+  line-height: 1.2;
+}
+
+.related-posts ul {
+  margin-top: 1rem;
+}
+
+.related-posts li {
+  border-top: 1px solid var(--site-soft);
+}
+
+.related-posts li:last-child {
+  border-bottom: 1px solid var(--site-soft);
+}
+
+.related-posts a {
+  display: block;
+  padding: 1rem 0;
 }
 
 .experiment-note {
@@ -315,5 +424,13 @@ body {
 
   .post-card-body h2 {
     max-width: 100%;
+  }
+
+  .post-page {
+    padding-top: 2.5rem;
+  }
+
+  .post-nav {
+    grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- restyle individual post pages with an editorial header and dek
- add previous/next post navigation
- add related posts based on shared tags

## Verification
- JEKYLL_ENV=production bundle _2.6.9_ exec jekyll build